### PR TITLE
fix: add inquirer dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
     "changelog": "node scripts/generate-changelog.js"
   },
   "devDependencies": {
-    "conventional-changelog-cli": "^5.0.0"
+    "conventional-changelog-cli": "^5.0.0",
+    "inquirer": "^12.9.0"
   },
   "author": "Green <greenarmor@live.com>",
   "license": "MIT",


### PR DESCRIPTION
## Summary
- add `inquirer` so bump CLI runs without missing module errors

## Testing
- `npm test` (fails: Missing script: "test")
- `printf '\n' | node scripts/bump-cli.js --dry-run`


------
https://chatgpt.com/codex/tasks/task_e_689049372c34832ab62b1b159f459236