### PR TITLE
Potential fix for code scanning alert no. 5: Shell command built from environment values

### DIFF
--- a/scripts/bump-cli.js
+++ b/scripts/bump-cli.js
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 
 import inquirer from 'inquirer';
-import { execSync } from 'child_process';
+import { execSync, execFileSync } from 'child_process';
 import fs from 'fs';
 import path from 'path';
 import { fileURLToPath } from 'url';
@@ -51,9 +51,9 @@ try {
 console.log(`\nGitHub Release Notes (generated):\n`);
 try {
   const changelogCli = path.resolve(__dirname, '../node_modules/conventional-changelog-cli/cli.js');
-  const flags = [`-p angular`, `-r ${releaseCount}`];
+  const flags = ['-p', 'angular', '-r', String(releaseCount)];
   if (unreleased) flags.push('-u');
-  const releaseNotes = execSync(`node ${changelogCli} ${flags.join(' ')}`, { encoding: 'utf8' });
+  const releaseNotes = execFileSync('node', [changelogCli, ...flags], { encoding: 'utf8' });
   console.log(releaseNotes || 'No generated release notes.');
 } catch (err) {
   console.warn('Failed to generate GitHub release notes.');


### PR DESCRIPTION
Potential fix for [https://github.com/greenarmor/cli-boilerplate/security/code-scanning/5](https://github.com/greenarmor/cli-boilerplate/security/code-scanning/5)

To fix the problem, we should avoid constructing a shell command string and passing it to `execSync`, which invokes a shell and is vulnerable to shell injection. Instead, we should use `execFileSync`, which takes the command and its arguments as separate parameters, thus avoiding shell interpretation and injection risks. Specifically, we should:

- Replace the use of `execSync` with `execFileSync` for running the changelog CLI.
- Pass the path to the Node executable (`node`), the script path (`changelogCli`), and the flags as separate arguments in an array.
- Import `execFileSync` from `child_process` if not already imported.
- Ensure that all arguments are passed as array elements, not as a single string.

This change should be made only to the block that generates the release notes (lines 53–57). No other code needs to be changed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
