### PR TITLE
Potential fix for code scanning alert no. 4: Shell command built from environment values

### DIFF
--- a/scripts/generate-changelog.js
+++ b/scripts/generate-changelog.js
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 
-import { execSync } from 'child_process';
+import { execFileSync } from 'child_process';
 import path from 'path';
 import { fileURLToPath } from 'url';
 
@@ -10,7 +10,7 @@ const __dirname = path.dirname(__filename);
 
 try {
   const cliPath = path.resolve(__dirname, '../node_modules/conventional-changelog-cli/cli.js');
-  execSync(`node ${cliPath} -p angular -i CHANGELOG.md -s -r 0`, {
+  execFileSync('node', [cliPath, '-p', 'angular', '-i', 'CHANGELOG.md', '-s', '-r', '0'], {
     stdio: 'inherit'
   });
   console.log('Changelog generated successfully.');


### PR DESCRIPTION
Potential fix for [https://github.com/greenarmor/cli-boilerplate/security/code-scanning/4](https://github.com/greenarmor/cli-boilerplate/security/code-scanning/4)

To fix the problem, we should avoid passing a dynamically constructed command string to `execSync`, which invokes a shell and interprets the string. Instead, we should use `execFileSync`, which takes the command and its arguments as separate parameters, avoiding shell interpretation and injection risks. Specifically, we should replace the call to `execSync` with `execFileSync`, passing `"node"` as the command and the CLI path and other arguments as an array. This change should be made in `scripts/generate-changelog.js` on line 13. We also need to import `execFileSync` from `child_process` instead of (or in addition to) `execSync`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
