### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -9,6 +9,8 @@ on:
 
 jobs:
   deploy:
+    permissions:
+      contents: write
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code


### PR DESCRIPTION
Potential fix for [https://github.com/greenarmor/cli-boilerplate/security/code-scanning/1](https://github.com/greenarmor/cli-boilerplate/security/code-scanning/1)

To fix the problem, you should add a `permissions` block to the workflow or to the specific job. Since the workflow only contains a single job (`deploy`), you can add the `permissions` block either at the root level (applies to all jobs) or at the job level (applies only to `deploy`). The minimal required permission for deploying to GitHub Pages is `contents: write`, as the action needs to push to the `gh-pages` branch. Therefore, add the following block under the `deploy` job:

```yaml
permissions:
  contents: write
```

This should be placed directly under `deploy:` and before `runs-on:`. No additional imports or definitions are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
